### PR TITLE
Fix assignments by using `didSet` of the wrappedValue property

### DIFF
--- a/Sources/UseAutoLayout/UseAutoLayout.swift
+++ b/Sources/UseAutoLayout/UseAutoLayout.swift
@@ -3,15 +3,14 @@ import UIKit
 
 @propertyWrapper
 public struct UseAutoLayout<T: UIView> {
-    var value: T
-
-    public var wrappedValue: T {
-      get { return value }
-      set { self.value.translatesAutoresizingMaskIntoConstraints = false }
+    var wrappedValue: T {
+        didSet {
+            self.wrappedValue.translatesAutoresizingMaskIntoConstraints = false
+        }
     }
 
     public init(wrappedValue: T) {
-      value = wrappedValue
+      self.wrappedValue = wrappedValue
     }
 }
 #endif


### PR DESCRIPTION
Previously, assignments would not store the new value of `wrappedValue`, since the setter `set {}` only changed the `translatesAutoresizingMaskIntoConstraints` of the view.

Now, we don’t override the default `wrappedValue` setter `set {}`, but `didSet {}` instead. There we change the `translatesAutoresizingMaskIntoConstraints` of the new view.